### PR TITLE
feat!: Return null when no item is found.

### DIFF
--- a/lib/src/bloc_base/queryable.dart
+++ b/lib/src/bloc_base/queryable.dart
@@ -1,24 +1,67 @@
 import 'package:bloc/bloc.dart';
-import 'package:bloc_infinite_list/src/bloc/infinite_list_state.dart';
-import 'package:collection/collection.dart';
+import 'package:bloc_infinite_list/bloc_infinite_list.dart';
+
+/// A mixin that provides query methods for [InfiniteListState].
 
 mixin InfiniteListQueryable<ElementType,
     State extends InfiniteListState<ElementType, State>> on BlocBase<State> {
+  /// Gets the element at the given [index].
   ElementType operator [](int index) => state.infList[index];
 
-  int indexOf(ElementType item) => state.infList.indexOf(item);
+  /// Gets the sub list of the given `[start, end)` range.
+  /// This returns half-open range which means that
+  /// [start] is included but the the item of [end] index is not included.
+  Iterable<ElementType> getRange(int start, int end) =>
+      state.infList.getRange(start, end);
 
-  int indexWhere(bool Function(ElementType item) test) =>
+  /// Finds the index of the given [item].
+  /// Returns `null` if the item is not found.
+  /// Port of `Iterable.indexOf`.
+  int? indexOf(ElementType item) => state.infList.indexOf(item);
+
+  /// Finds the index of given [item] that starts searching from the end.
+  /// Returns `null` if the item is not found.
+  /// Port of [InfiniteList.lastIndexOf].
+  int? lastIndexOf(ElementType item) => state.infList.lastIndexOf(item);
+
+  /// Finds the index of the first element that satisfies the [test].
+  /// Returns `null` if no element satisfies the [test].
+  /// Port of `Iterable.indexWhere`.
+  int? indexWhere(bool Function(ElementType item) test) =>
       state.infList.indexWhere(test);
 
+  /// Finds the index of the last element that satisfies the [test].
+  /// Returns `null` if no element satisfies the [test].
+  int? lastIndexWhere(bool Function(ElementType item) test) =>
+      state.infList.lastIndexWhere(test);
+
+  /// Finds the first element that satisfies the [test].
+  /// Returns `null` if no element satisfies the [test].
+  ///
+  /// Port of [InfiniteList.firstWhereOrNull].
+  ElementType? firstWhereOrNull(bool Function(ElementType item) test) =>
+      state.infList.firstWhereOrNull(test);
+
+  /// Finds all elements that satisfy the [test].
+  /// Port of `Iterable.where`.
   Iterable<ElementType> where(bool Function(ElementType item) test) =>
       state.infList.where(test);
 
+  /// Finds the single element that satisfies the [test].
+  ///
+  /// If there is no element that satisfies the [test], or if there is more than
+  /// one element that satisfies the [test], this returns `null`.
+  ///
+  /// Port of [InfiniteList.singleWhereOrNull].
   ElementType? singleWhereOrNull(bool Function(ElementType item) test) =>
-      state.infList.items.singleWhereOrNull(test);
+      state.infList.singleWhereOrNull(test);
 
+  /// Inspects whether there is an element that satisfies the [test].
   bool containsWhere(bool Function(ElementType item) test) =>
-      singleWhereOrNull(test) != null;
+      state.infList.containsWhere(test);
 
-  bool contains(ElementType item) => state.infList.items.contains(item);
+  /// Inspects whether the [item] is contained in the list.
+  ///
+  /// Port of [InfiniteList.contains].
+  bool contains(ElementType item) => state.infList.contains(item);
 }

--- a/lib/src/model/infinite_list.dart
+++ b/lib/src/model/infinite_list.dart
@@ -22,6 +22,8 @@ enum InfiniteListStatus {
   bool get isLoadCompleted => this == loadCompleted;
 }
 
+const _IDX_NOT_FOUND = -1;
+
 class InfiniteList<T> extends Equatable {
   const InfiniteList({
     this.items = const [],
@@ -70,19 +72,41 @@ class InfiniteList<T> extends Equatable {
 
   bool get isFetchNotNeeded => status.isLoadCompleted || status.isLoading;
 
-  int indexOf(T item) => items.indexOf(item);
+  int? indexOf(T item) {
+    final result = items.indexOf(item);
+    return result == _IDX_NOT_FOUND ? null : result;
+  }
 
-  int indexWhere(bool Function(T item) test) => items.indexWhere(test);
+  int? lastIndexOf(T item) {
+    final result = items.lastIndexOf(item);
+    return result == _IDX_NOT_FOUND ? null : result;
+  }
+
+  int? indexWhere(bool Function(T item) test) {
+    final result = items.indexWhere(test);
+    return result == _IDX_NOT_FOUND ? null : result;
+  }
+
+  int? lastIndexWhere(bool Function(T item) test) {
+    final result = items.lastIndexWhere(test);
+    return result == _IDX_NOT_FOUND ? null : result;
+  }
+
+  T? firstWhereOrNull(bool Function(T item) test) =>
+      items.firstWhereOrNull(test);
 
   Iterable<T> where(bool Function(T item) test) => items.where(test);
 
+  /// Port of `Iterable.singleWhereOrNull`.
   T? singleWhereOrNull(bool Function(T item) test) =>
       items.singleWhereOrNull(test);
 
   bool containsWhere(bool Function(T item) test) =>
-      singleWhereOrNull(test) != null;
+      firstWhereOrNull(test) != null;
 
   bool contains(T item) => items.contains(item);
+
+  Iterable<T> getRange(int start, int end) => items.getRange(start, end);
 
   /// ------------------------------------------ End Queries
 


### PR DESCRIPTION
Methods that find the item's index now return null if there is no finding item located in the list.

The affecting methods are:
1. indexOf()
2. lastIndexOf()
3. indexWhere()
4. lastIndexWhere()


Closes #9 
